### PR TITLE
Fix typo on Albert Einstein

### DIFF
--- a/data/albert-einstein.json
+++ b/data/albert-einstein.json
@@ -40,7 +40,7 @@
         "role": "author",
         "title": "On linear independence of sequences in a Banach space",
         "source": "http://www.ams.org/mathscinet-getitem?mr=58863",
-        "collaborator": "Paul Erdős</li>",
+        "collaborator": "Paul Erdős",
         "collaborator_role": "author"
       }
     ]


### PR DESCRIPTION
Remove extraneous </li> item.